### PR TITLE
fix VS build + remove extra nonce count in plot file name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@
 *.exe
 *.out
 *.app
+
+# Generated files
+*.opensdf
+*.sdf
+ipch/
+x64/

--- a/XPlotter.cpp
+++ b/XPlotter.cpp
@@ -341,7 +341,7 @@ int main(int argc, char* argv[])
 	// ajusting nonces 
 	nonces = (nonces / (bytesPerSector / SCOOP_SIZE)) * (bytesPerSector / SCOOP_SIZE);
 
-	std::string filename = std::to_string(addr) + "_" + std::to_string(startnonce) + "_" + std::to_string(nonces) + "_" + std::to_string(nonces);
+	std::string filename = std::to_string(addr) + "_" + std::to_string(startnonce) + "_" + std::to_string(nonces);
 	
 	BOOL granted = SetPrivilege();
 

--- a/XPlotter.sln
+++ b/XPlotter.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
 VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "XPlotter", "XPlotter\XPlotter.vcxproj", "{48AEE4CD-8F38-4CCE-A72B-2D81A9AEE4B1}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "XPlotter", "XPlotter.vcxproj", "{48AEE4CD-8F38-4CCE-A72B-2D81A9AEE4B1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
1. The .sln expected to find vcproj in a sub folder. Fixed to use the vcproj in root directory.
2. The plotter files were having the nonce count twice in the plot name. (addr_startnonce_nonces_nonces)