### PR TITLE
fixed printColouredMessage from printing std::strings improperly

### DIFF
--- a/XPlotter.cpp
+++ b/XPlotter.cpp
@@ -15,13 +15,13 @@ unsigned long long written_scoops = 0;
 
 void printColouredMessage(std::string message, WORD colour) {
 	SetConsoleTextAttribute(hConsole, colour);
-	printf("%s", message);
+	std::printf("%s", message.c_str());
 	SetConsoleTextAttribute(hConsole, colour::GRAY);
 }
 
 void printLastError(std::string message) {
 	SetConsoleTextAttribute(hConsole, colour::RED);
-	printf("%s (code = %u) \n", message, GetLastError());
+	std::printf("%s (code = %u) \n", message.c_str(), GetLastError());
 	SetConsoleTextAttribute(hConsole, colour::GRAY);
 }
 


### PR DESCRIPTION
colored message is printing garbled at times.

1>XPlotter.cpp(18): warning C4477: 'printf' : format string '%s' requires an argument of type 'char *', but variadic argument 1 has type 'std::string'
1>XPlotter.cpp(24): warning C4477: 'printf' : format string '%s' requires an argument of type 'char *', but variadic argument 1 has type 'std::string'